### PR TITLE
[API] Add Cache

### DIFF
--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -122,7 +122,7 @@ class ResourceController extends Controller
      */
     public function importResources(Request $request){
 
-        // To DO Vérification
+        // To DO Check for each resource requirements
 
         CacheManager::cleanCache($withImage = true);
         

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use App\Tag;
 use App\ResourceTag;
 use App\Http\Requests\TagRequest;
+use App\Services\Cache\CacheManager;
 
 class TagController extends Controller
 {
@@ -17,7 +19,12 @@ class TagController extends Controller
      */
     public function indexPublic(Request $request)
     {
-        $tags = Tag::loadMainTags();
+        $tags = Cache::remember(
+            CacheManager::getCachedObjectName('public_tags_index'),
+            CacheManager::getCachedObjectExpiration('public_tags_index'),
+            function () {
+                return Tag::loadMainTags();
+        });
 
         return response()->json($tags, 200);
     }

--- a/app/Services/Cache/CacheManager.php
+++ b/app/Services/Cache/CacheManager.php
@@ -81,6 +81,8 @@ class CacheManager
         if($withImage){
             return Cache::flush();
         }
+
+        // ToDO with MemCache, remove cached objects by Tag
         
         if (Cache::has('public_tags_index')) {
             Cache::forget('public_tags_index');

--- a/app/Services/Cache/CacheManager.php
+++ b/app/Services/Cache/CacheManager.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Services\Cache;
+
+use Illuminate\Support\Facades\Cache;
+use Exception;
+
+class CacheManager
+{
+
+    /**
+     * Get Cached Objects Expiration (in seconds)
+     * 
+     */
+    public static function getCachedObjectExpiration(string $object_type)
+    {
+        switch ($object_type) {
+        
+            case 'public_tags_index':
+                return CachedObjectExpiration::PUBLIC_TAGS_INDEX;
+            
+            case 'public_resources_research':
+                return CachedObjectExpiration::PUBLIC_RESOURCES_RESEARCH;
+
+            case 'resources_images':
+                return CachedObjectExpiration::RESOURCES_IMAGE;
+
+            default:
+                throw new Exception("No Cached Object Expiration found", 1);
+        }
+    }    
+
+    /**
+     * Get Cached Objects Name
+     * 
+     */
+    public static function getCachedObjectName(string $object_type, $object_id = null)
+    {
+        switch ($object_type) {
+        
+            case 'public_tags_index':
+                return CachedObjectBaseName::PUBLIC_TAGS_INDEX;
+            
+            case 'public_resources_research':
+                if ($object_id !== null) {
+                    return CachedObjectBaseName::PUBLIC_RESOURCES_RESEARCH."_".$object_id;
+                }
+                throw new Exception("Cache Manager : No ObjectId provided");
+
+            case 'resources_images':
+                if ($object_id !== null) {
+                    return CachedObjectBaseName::RESOURCES_IMAGE."_".$object_id;
+                }
+                throw new Exception("Cache Manager : No ObjectId provided");
+
+            default:
+                throw new Exception("No Cached Object Name found");            
+        }
+    }
+
+    /**
+     * Remove specific resource image cache
+     * 
+     */
+    public static function removeResourceImageCache($resource_image_id)
+    {
+        $cached_key = CacheManager::getCachedObjectName('resources_images', $resource_image_id);
+
+        if(Cache::has($cached_key))
+        {
+            Cache::forget($cached_key);
+        }
+    }
+
+    /**
+     * Clean cache
+     * 
+     */
+    public static function cleanCache($withImage = false)
+    {
+        if($withImage){
+            return Cache::flush();
+        }
+        
+        if (Cache::has('public_tags_index')) {
+            Cache::forget('public_tags_index');
+        }
+    }
+}

--- a/app/Services/Cache/CachedObjectBaseName.php
+++ b/app/Services/Cache/CachedObjectBaseName.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Services\Cache;
+
+abstract class CachedObjectBaseName
+{
+
+    const PUBLIC_TAGS_INDEX = 'public_tags_index';
+    const PUBLIC_RESOURCES_RESEARCH = 'public_resources_research';
+    const RESOURCES_IMAGE = 'resources_images';
+   
+}

--- a/app/Services/Cache/CachedObjectExpiration.php
+++ b/app/Services/Cache/CachedObjectExpiration.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Services\Cache;
+
+abstract class CachedObjectExpiration
+{
+    // Expiration Time in Second
+
+    const PUBLIC_TAGS_INDEX = 60 * 60 * 24; // 1 day
+    const PUBLIC_RESOURCES_RESEARCH = 60 * 60 * 24; // 1 day
+    const RESOURCES_IMAGE = 60 * 60 * 24 * 30; // 1 month
+
+}


### PR DESCRIPTION
1st Step : 
- Add basic Cache for tags, resources research & resource images (avoid S3 bucket requests)

### ToDO (Later)

2nd Step : 
- Cache with MemCache
Heroku erased all files at each deployment, this is why managing cache could be better with MemCache.
Exemple : https://devcenter.heroku.com/articles/laravel-memcache
Heroku Addon : https://elements.heroku.com/addons/memcachier
We'll need to manage cache depending environment (with files in local environment, with MemCache online). This will be implemented in the Cache Manager.

Furthermore we can add tags with MemCache such as `Resources_Research` and may flush cached objects with those tags. This is interesting as we may need to remove all resources research cached objects (which have all different name `public_resources_research_{tags_slug_list}`) without removing resources image cached objects.