### PR TITLE
Fix import of the SPA

### DIFF
--- a/resources/views/main.blade.php
+++ b/resources/views/main.blade.php
@@ -13,6 +13,6 @@
 	<noscript>
         You need to enable JavaScript to run this app.
     </noscript>
-	<script src="js/app-main.js"></script>
+	<script src="/js/app-main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This fixes the reloading of the results page by adding `/` at the beginning of the URL when importing the SPA javascript bundle.