### PR TITLE
Help text on home page

### DIFF
--- a/react/app-main/components/SearchPage/SearchPage.tsx
+++ b/react/app-main/components/SearchPage/SearchPage.tsx
@@ -14,6 +14,16 @@ export const SearchPage: React.FunctionComponent = () => {
                 websites for your <span className="search-page__title--bold">workflow</span>
             </p>
             <TagsSelector />
+            <div className="search-page__help-container">
+                <div className="search-page__help-content">
+                    TipsMyWeb makes you discover new web resources to help with your day to day
+                    workflow.
+                    <br />
+                    <span className="search-page__help--small">
+                        Start by selecting tags corresponding to your subject of interest.
+                    </span>
+                </div>
+            </div>
         </div>
     );
 };

--- a/react/app-main/components/SearchPage/SearchPage.tsx
+++ b/react/app-main/components/SearchPage/SearchPage.tsx
@@ -1,3 +1,5 @@
+import { faQuestion } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import * as React from 'react';
 import { DocumentHead } from 'tmw-main/components/DocumentHead';
 import { TagsSelector } from 'tmw-main/components/TagsSelector';
@@ -16,12 +18,15 @@ export const SearchPage: React.FunctionComponent = () => {
             <TagsSelector />
             <div className="search-page__help-container">
                 <div className="search-page__help-content">
-                    TipsMyWeb makes you discover new web resources to help with your day to day
-                    workflow.
-                    <br />
-                    <span className="search-page__help--small">
-                        Start by selecting tags corresponding to your subject of interest.
+                    <span className="search-page__help-content-text">
+                        TipsMyWeb makes you discover new web resources to help with your day to day
+                        workflow.
+                        <br />
+                        <span className="search-page__help--small">
+                            Start by selecting tags corresponding to your subject of interest.
+                        </span>
                     </span>
+                    <FontAwesomeIcon className="search-page__help-content-icon" icon={faQuestion} />
                 </div>
             </div>
         </div>

--- a/react/app-main/components/SearchPage/search-page.less
+++ b/react/app-main/components/SearchPage/search-page.less
@@ -50,6 +50,11 @@
             margin-top: 10px;
             opacity: 0.5;
 
+            @media (max-width: @app-viewport-breakpoint-mobile) {
+                font-size: 12px;
+                padding: 7px 10px;
+            }
+
             &:hover {
                 padding: 8px 30px;
                 font-size: 15px;
@@ -57,6 +62,15 @@
                 opacity: 1;
 
                 transition: opacity 0.3s ease-in-out;
+
+                @media (max-width: @app-viewport-breakpoint-mobile) {
+                    font-size: 12px;
+                    padding: 8px 25px;
+                }
+
+                @media (max-width: @app-viewport-breakpoint-tablet) {
+                    border-radius: 8px;
+                }
             }
 
             &-text {
@@ -77,6 +91,10 @@
            margin-top: 5px;
            font-family: @app-font-semi-bold;
            font-size: @app-font-size-medium;
+
+           @media (max-width: @app-viewport-breakpoint-mobile) {
+               font-size: 10px;
+           }
        }
     }
 }

--- a/react/app-main/components/SearchPage/search-page.less
+++ b/react/app-main/components/SearchPage/search-page.less
@@ -26,4 +26,35 @@
             font-family: @app-font-semi-bold;
         }
     }
+
+    &__help {
+
+        &-container {
+            text-align: center;
+            margin-top: 100px;
+        }
+
+        &-content {
+            display: inline-block;
+            font-family: @app-font-regular;
+            font-size: 15px;
+            text-align: center;
+
+            background-color: rgba(255, 255, 255, 0.7);
+            color: @app-color-background-red;
+            border-radius: 40px;
+            padding: 8px 30px;
+            margin-left: auto;
+            margin-right: auto;
+
+            @media (max-width: @app-viewport-breakpoint-mobile) {
+                font-size: 6vw;
+            }
+        }
+
+       &--small {
+           font-family: @app-font-semi-bold;
+           font-size: @app-font-size-medium;
+       }
+    }
 }

--- a/react/app-main/components/SearchPage/search-page.less
+++ b/react/app-main/components/SearchPage/search-page.less
@@ -37,22 +37,44 @@
         &-content {
             display: inline-block;
             font-family: @app-font-regular;
-            font-size: 15px;
             text-align: center;
-
+            cursor: pointer;
             background-color: rgba(255, 255, 255, 0.7);
             color: @app-color-background-red;
             border-radius: 40px;
-            padding: 8px 30px;
             margin-left: auto;
             margin-right: auto;
 
-            @media (max-width: @app-viewport-breakpoint-mobile) {
-                font-size: 6vw;
+            font-size: 14px;
+            padding: 8px 12px;
+            margin-top: 10px;
+            opacity: 0.5;
+
+            &:hover {
+                padding: 8px 30px;
+                font-size: 15px;
+                margin-top: 0;
+                opacity: 1;
+
+                transition: opacity 0.3s ease-in-out;
+            }
+
+            &-text {
+                display: none;
+            }
+
+            &:hover &-text {
+                display: inline;
+            }
+
+            &:hover &-icon {
+                display: none;
             }
         }
 
        &--small {
+           display: inline-block;
+           margin-top: 5px;
            font-family: @app-font-semi-bold;
            font-size: @app-font-size-medium;
        }

--- a/react/app-main/constants/ui-constants.less
+++ b/react/app-main/constants/ui-constants.less
@@ -47,5 +47,6 @@
 @app-color-light-grey-3: #d0d0d0;
 
 @app-viewport-breakpoint-mobile: 450px;
+@app-viewport-breakpoint-tablet: 850px;
 
 @app-curve-in-out-cubic: cubic-bezier(0.65, 0.05, 0.36, 1);


### PR DESCRIPTION
 Add a help text on the home page (shown on hover of a help button)

<img width="841" alt="Screenshot 2020-11-22 at 14 40 14" src="https://user-images.githubusercontent.com/45501795/99905598-19a61080-2cd2-11eb-950a-c868b05c333b.png">
